### PR TITLE
feat: add category filter to /freshrss/unread

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The API provides interactive documentation at:
 ## Available Endpoints
 
 - `GET /freshrss/unread` - Fetch unread RSS items from FreshRSS
+  - Optional query parameters:
+    - `n` (integer, default `10`) - Number of unread items to return
+    - `category` (string) - FreshRSS category label to scope unread items, e.g. `/freshrss/unread?category=Tech`
 
 Example of services.yaml:
 

--- a/main.py
+++ b/main.py
@@ -66,7 +66,10 @@ def health():
 
 
 @app.get("/freshrss/unread")
-def freshrss_unread(n: int = Query(default=10, ge=1)):
+def freshrss_unread(
+    n: int = Query(default=10, ge=1),
+    category: str | None = Query(default=None),
+):
     token = get_greader_token()
     headers = {"Authorization": f"GoogleLogin auth={token}"}
     params = {
@@ -74,8 +77,9 @@ def freshrss_unread(n: int = Query(default=10, ge=1)):
         "output": "json",
         "n": n,
     }
+    stream_id = f"user/-/label/{category}" if category else "user/-/state/com.google/reading-list"
     # Using the same host as before but with the right endpoint
-    url = f"{FRESHRSS_HOST}/api/greader.php/reader/api/0/stream/contents/user/-/state/com.google/reading-list"
+    url = f"{FRESHRSS_HOST}/api/greader.php/reader/api/0/stream/contents/{stream_id}"
     r = requests.get(url, headers=headers, params=params, timeout=10)
     r.raise_for_status()
     raw = r.json()


### PR DESCRIPTION
## Summary
- Add optional `category` query parameter to `GET /freshrss/unread`
- Use FreshRSS/GReader category stream IDs (`user/-/label/{category}`) when provided
- Preserve the existing unread/read exclusion filter, item count behavior, auth, and response format
- Document `n` and `category` query parameters in the README endpoint section

## Verification
- `uv run python -m compileall main.py`
- `PYTHONPATH=. uv run python /tmp/hermes-verify-rss-api-category.py`
  - verified default stream remains `user/-/state/com.google/reading-list`
  - verified `category=Tech` uses `user/-/label/Tech`
  - verified `xt=user/-/state/com.google/read` remains unchanged
  - verified OpenAPI includes optional `category`

Closes #13
