### PR TITLE
Bound unread item query count

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The API provides interactive documentation at:
 
 - `GET /freshrss/unread` - Fetch unread RSS items from FreshRSS
   - Optional query parameters:
-    - `n` (integer, default `10`) - Number of unread items to return
+    - `n` (integer, default `10`, valid range `1`–`100`) - Number of unread items to return
     - `category` (string) - FreshRSS category label to scope unread items, e.g. `/freshrss/unread?category=Tech`
 
 ## Testing

--- a/main.py
+++ b/main.py
@@ -71,7 +71,7 @@ def health():
 
 @app.get("/freshrss/unread")
 def freshrss_unread(
-    n: int = Query(default=10, ge=1),
+    n: int = Query(default=10, ge=1, le=100),
     category: str | None = Query(default=None),
 ):
     token = get_greader_token()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "httpx2>=2.0.0",
     "pytest>=8.0.0",
 ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 import requests
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -161,6 +162,40 @@ def test_freshrss_unread_fetches_reading_list_and_shapes_items(monkeypatch):
     assert result[0]["published"] == 1700000000
     assert result[0]["url"] == "https://example.test/release"
     assert result[0]["display"].startswith("Release shipped • ")
+
+
+@pytest.mark.parametrize("n", [0, 101])
+def test_freshrss_unread_rejects_out_of_range_n_without_contacting_freshrss(monkeypatch, n):
+    main = import_app(monkeypatch)
+
+    def unexpected_request(*args, **kwargs):
+        pytest.fail("FreshRSS must not be contacted for an invalid n value")
+
+    monkeypatch.setattr(main.requests, "post", unexpected_request)
+    monkeypatch.setattr(main.requests, "get", unexpected_request)
+
+    response = TestClient(main.app).get("/freshrss/unread", params={"n": n})
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("n", [1, 100])
+def test_freshrss_unread_accepts_boundary_n_values(monkeypatch, n):
+    main = import_app(monkeypatch)
+    monkeypatch.setattr(main, "get_greader_token", lambda: "token-123")
+    captured = {}
+
+    def fake_get(url, headers, params, timeout):
+        captured["n"] = params["n"]
+        return FakeResponse(payload={"items": []})
+
+    monkeypatch.setattr(main.requests, "get", fake_get)
+
+    response = TestClient(main.app).get("/freshrss/unread", params={"n": n})
+
+    assert response.status_code == 200
+    assert response.json() == []
+    assert captured["n"] == n
 
 
 def test_freshrss_unread_scopes_to_category_and_handles_missing_url(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent dashboard integrations from requesting an unbounded number of items and ensure invalid values are rejected before contacting FreshRSS.
- Make the valid `n` range explicit in the documentation for dashboard authors and operators.

### Description
- Add an upper bound to the `n` query parameter in `freshrss_unread` with `Query(default=10, ge=1, le=100)` in `main.py`.
- Update `README.md` to document the valid `n` range as `1`–`100` for the `/freshrss/unread` endpoint.
- Add API-level tests in `tests/test_main.py` that use `fastapi.testclient.TestClient` to verify out-of-range values (`0` and `101`) return HTTP 422 without contacting FreshRSS and that boundary values (`1` and `100`) are accepted and forwarded.
- Add `httpx2` to the development dependency group in `pyproject.toml` to satisfy `TestClient`'s transport requirement.

### Testing
- `python -m py_compile main.py tests/test_main.py` ran successfully and reported no syntax errors.
- `git diff --check` was run and reported no issues.
- `uv run pytest` attempted test collection but failed because `starlette.testclient` requires the `httpx2` package; `httpx2` was added to the `dev` dependencies, however installation could not be completed in this environment due to inability to fetch packages from PyPI, so pytest could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dea733164832597e69b5aca6770ed)