### PR TITLE
Redact sensitive FreshRSS login failure logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from urllib.parse import urlsplit
 from fastapi import FastAPI, HTTPException, Query
 import requests
 import humanize
@@ -54,7 +55,12 @@ def get_greader_token():
         logging.warning("FreshRSS login request failed: %s", exc)
         raise HTTPException(status_code=502, detail="FreshRSS login request failed") from exc
     if res.status_code != 200:
-        logging.warning("FreshRSS login failed (status %d): %s", res.status_code, res.text)
+        upstream_host = urlsplit(FRESHRSS_HOST).hostname or "unknown"
+        logging.warning(
+            "FreshRSS login failed (status=%d, upstream_host=%s)",
+            res.status_code,
+            upstream_host,
+        )
         raise HTTPException(status_code=502, detail=f"FreshRSS login failed with status {res.status_code}")
     # Find and extract 'Auth=' line
     for line in res.text.splitlines():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,15 +84,30 @@ def test_get_greader_token_logs_in_once_and_caches_token(monkeypatch):
     ]
 
 
-def test_get_greader_token_rejects_failed_login(monkeypatch):
-    main = import_app(monkeypatch)
-    monkeypatch.setattr(main.requests, "post", lambda *args, **kwargs: FakeResponse(status_code=403, text="nope"))
+def test_get_greader_token_rejects_failed_login_without_logging_secrets(monkeypatch, caplog):
+    credentials = {
+        "FRESHRSS_HOST": "https://freshrss.example.test",
+        "FRESHRSS_USER": "sentinel-username",
+        "FRESHRSS_PASS": "sentinel-password",
+    }
+    main = import_app(monkeypatch, credentials)
+    response_body = "sentinel-response-body\nAuth=sentinel-token"
+    monkeypatch.setattr(
+        main.requests,
+        "post",
+        lambda *args, **kwargs: FakeResponse(status_code=403, text=response_body),
+    )
 
-    with pytest.raises(HTTPException) as excinfo:
-        main.get_greader_token()
+    with caplog.at_level("WARNING"):
+        with pytest.raises(HTTPException) as excinfo:
+            main.get_greader_token()
 
     assert excinfo.value.status_code == 502
     assert "FreshRSS login failed with status 403" == excinfo.value.detail
+    assert "status=403" in caplog.text
+    assert "upstream_host=freshrss.example.test" in caplog.text
+    for secret in (*credentials.values(), response_body, "sentinel-token"):
+        assert secret not in caplog.text
 
 
 def test_get_greader_token_rejects_missing_auth_line(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent sensitive data from being emitted when FreshRSS login fails by avoiding logging the upstream response body and configured credentials while retaining minimal diagnostic metadata.

### Description
- Replace the failed-login log line to only include the HTTP status and the parsed upstream hostname using `urlsplit` in `main.py`.
- Remove logging of the upstream response body and any credentials or tokens from the warning path in `get_greader_token()`.
- Add a `caplog` regression test `test_get_greader_token_rejects_failed_login_without_logging_secrets` in `tests/test_main.py` that asserts the status and upstream host are present in logs and that sentinel credentials, response body, and token values are never logged.

### Testing
- Ran the project test suite via the project runner with `uv run pytest -q`, which completed successfully with `9 passed`.
- Running `pytest -q` directly in the environment failed during collection due to `fastapi` not being installed globally, which is an environment issue and not related to the changes. 
- Ran `git diff --check` to validate the diff for formatting issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5deadbc3f483259ba7f99b622c0453)