### PR TITLE
Normalize and safely encode FreshRSS categories

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import logging
 import os
+from urllib.parse import quote
+
 from fastapi import FastAPI, HTTPException, Query
 import requests
 import humanize
@@ -72,7 +74,7 @@ def health():
 @app.get("/freshrss/unread")
 def freshrss_unread(
     n: int = Query(default=10, ge=1),
-    category: str | None = Query(default=None),
+    category: str | None = Query(default=None, max_length=200),
 ):
     token = get_greader_token()
     headers = {"Authorization": f"GoogleLogin auth={token}"}
@@ -81,8 +83,12 @@ def freshrss_unread(
         "output": "json",
         "n": n,
     }
-    category_label = category if isinstance(category, str) and category else None
-    stream_id = f"user/-/label/{category_label}" if category_label else "user/-/state/com.google/reading-list"
+    category_label = category.strip() if isinstance(category, str) else None
+    stream_id = (
+        f"user/-/label/{quote(category_label, safe='')}"
+        if category_label
+        else "user/-/state/com.google/reading-list"
+    )
     # Using the same host as before but with the right endpoint
     url = f"{FRESHRSS_HOST}/api/greader.php/reader/api/0/stream/contents/{stream_id}"
     try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -193,6 +193,36 @@ def test_freshrss_unread_scopes_to_category_and_handles_missing_url(monkeypatch)
     assert result[0]["url"] == ""
 
 
+@pytest.mark.parametrize(
+    ("category", "expected_stream"),
+    [
+        ("  Tech News  ", "user/-/label/Tech%20News"),
+        ("Tech/News", "user/-/label/Tech%2FNews"),
+        ("100% News", "user/-/label/100%25%20News"),
+        ("What?", "user/-/label/What%3F"),
+        ("日本語", "user/-/label/%E6%97%A5%E6%9C%AC%E8%AA%9E"),
+        ("  \t\n ", "user/-/state/com.google/reading-list"),
+    ],
+)
+def test_freshrss_unread_normalizes_and_encodes_category(monkeypatch, category, expected_stream):
+    main = import_app(monkeypatch)
+    monkeypatch.setattr(main, "get_greader_token", lambda: "token-123")
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        return FakeResponse(payload={"items": []})
+
+    monkeypatch.setattr(main.requests, "get", fake_get)
+
+    main.freshrss_unread(category=category)
+
+    assert captured["url"] == (
+        "https://freshrss.example.test/api/greader.php/reader/api/0/stream/contents/"
+        f"{expected_stream}"
+    )
+
+
 def test_freshrss_unread_wraps_upstream_http_errors(monkeypatch):
     main = import_app(monkeypatch)
     monkeypatch.setattr(main, "get_greader_token", lambda: "token-123")


### PR DESCRIPTION
### Motivation

- Ensure `category` query values are canonicalized so user-supplied whitespace does not produce invalid or surprising upstream requests.
- Treat whitespace-only `category` values as if no category was provided, falling back to the reading list stream.
- Prevent unsafe path injection and preserve characters by encoding the label as a single URL path segment when constructing the FreshRSS stream URL.

### Description

- Add `from urllib.parse import quote` and use `quote(category_label, safe="")` to encode the category as one URL path segment before building the upstream stream path.
- Normalize the `category` parameter with `category.strip()` and treat non-string or empty/whitespace results as no category.
- Constrain the FastAPI `Query` for `category` with `max_length=200` to impose a reasonable query-string length limit.
- Add parameterized tests in `tests/test_main.py` (`test_freshrss_unread_normalizes_and_encodes_category`) that assert the exact upstream URL for categories containing spaces, slashes, percent signs, question marks, Unicode, and whitespace-only inputs.

### Testing

- Ran the test suite with `uv run pytest -q`, and all tests passed (`15 passed`).
- The new parameterized tests verify exact upstream URL construction and succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dec114a148325a1bfc117b6e4fc0e)