### PR TITLE
feat: optional bearer authentication with RSS_API_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 FRESHRSS_HOST=http://localhost:8020
 FRESHRSS_USER=your-freshrss-username
 FRESHRSS_PASS=your-freshrss-password
+
+# Secret required by clients in the Authorization: Bearer header
+RSS_API_TOKEN=replace-with-a-long-random-secret

--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ The API provides interactive documentation at:
   - Optional query parameters:
     - `n` (integer, default `10`) - Number of unread items to return
     - `category` (string) - FreshRSS category label to scope unread items, e.g. `/freshrss/unread?category=Tech`
+- `GET /health` - Container health endpoint (does not require authentication)
+
+## Authentication
+
+Set the required `RSS_API_TOKEN` environment variable to a long, random secret. All
+endpoints that access FreshRSS require that secret as a bearer token; `/health`
+remains unauthenticated so container health checks continue to work.
+
+```bash
+curl \
+  -H "Authorization: Bearer ${RSS_API_TOKEN}" \
+  "http://localhost:5000/freshrss/unread?n=10&category=Tech"
+```
+
+Clients such as Homepage must send the same header:
+
+```yaml
+headers:
+  Authorization: Bearer your-rss-api-token
+```
 
 ## Testing
 
@@ -42,6 +62,8 @@ Example of services.yaml:
               type: customapi
               name: Unread RSS
               url: http://192.168.0.11:5000/freshrss/unread
+              headers:
+                Authorization: Bearer your-rss-api-token
               display: dynamic-list
               mappings:
                 name: feed
@@ -56,6 +78,7 @@ You can configure environment variables directly in `docker-compose.yml` instead
 environment:
 	FRESHRSS_USER: "user"
 	FRESHRSS_PASS: "password"
+	RSS_API_TOKEN: "replace-with-a-long-random-secret"
 ```
 
 Edit these values in your `docker-compose.yml` to match your setup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,5 @@ services:
       FRESHRSS_HOST: "${FRESHRSS_HOST:-http://localhost:8020}"
       FRESHRSS_USER: "${FRESHRSS_USER}"
       FRESHRSS_PASS: "${FRESHRSS_PASS}"
+      RSS_API_TOKEN: "${RSS_API_TOKEN}"
     restart: unless-stopped

--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
 import logging
 import os
-from fastapi import FastAPI, HTTPException, Query
+import secrets
+
+from fastapi import Depends, FastAPI, HTTPException, Query, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 import requests
 import humanize
 from datetime import datetime, timezone
@@ -29,14 +32,37 @@ print(skull)
 FRESHRSS_HOST = os.environ.get("FRESHRSS_HOST")
 FRESHRSS_USERNAME = os.environ.get("FRESHRSS_USER")
 FRESHRSS_PASSWORD = os.environ.get("FRESHRSS_PASS")
+RSS_API_TOKEN = os.environ.get("RSS_API_TOKEN")
 
-_missing = [k for k, v in {"FRESHRSS_HOST": FRESHRSS_HOST, "FRESHRSS_USER": FRESHRSS_USERNAME, "FRESHRSS_PASS": FRESHRSS_PASSWORD}.items() if not v]
+_missing = [
+    key
+    for key, value in {
+        "FRESHRSS_HOST": FRESHRSS_HOST,
+        "FRESHRSS_USER": FRESHRSS_USERNAME,
+        "FRESHRSS_PASS": FRESHRSS_PASSWORD,
+        "RSS_API_TOKEN": RSS_API_TOKEN,
+    }.items()
+    if not value
+]
 if _missing:
     raise RuntimeError(f"Missing required environment variables: {', '.join(_missing)}")
 
 app = FastAPI()
+bearer_scheme = HTTPBearer(auto_error=False)
 
 AUTH_TOKEN = None
+
+
+def require_api_token(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+):
+    """Require the configured bearer token before accessing protected endpoints."""
+    if credentials is None or not secrets.compare_digest(credentials.credentials, RSS_API_TOKEN):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 def get_greader_token():
@@ -69,7 +95,7 @@ def health():
     return {"status": "ok"}
 
 
-@app.get("/freshrss/unread")
+@app.get("/freshrss/unread", dependencies=[Depends(require_api_token)])
 def freshrss_unread(
     n: int = Query(default=10, ge=1),
     category: str | None = Query(default=None),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 import requests
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,6 +16,7 @@ REQUIRED_ENV = {
     "FRESHRSS_HOST": "https://freshrss.example.test",
     "FRESHRSS_USER": "reader",
     "FRESHRSS_PASS": "secret",
+    "RSS_API_TOKEN": "api-test-token",
 }
 
 
@@ -54,13 +56,52 @@ def test_import_requires_freshrss_environment(monkeypatch):
     assert "FRESHRSS_HOST" in message
     assert "FRESHRSS_USER" in message
     assert "FRESHRSS_PASS" in message
+    assert "RSS_API_TOKEN" in message
 
 
 def test_health_endpoint_returns_ok(monkeypatch):
     main = import_app(monkeypatch)
 
-    assert main.health() == {"status": "ok"}
+    response = TestClient(main.app).get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
     assert any(route.path == "/health" for route in main.app.routes)
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [{}, {"Authorization": "Bearer wrong-token"}],
+    ids=["missing", "invalid"],
+)
+def test_unread_rejects_unauthorized_requests_without_contacting_freshrss(monkeypatch, headers):
+    main = import_app(monkeypatch)
+
+    def unexpected_request(*args, **kwargs):
+        pytest.fail("unauthorized requests must not contact FreshRSS")
+
+    monkeypatch.setattr(main.requests, "post", unexpected_request)
+    monkeypatch.setattr(main.requests, "get", unexpected_request)
+
+    response = TestClient(main.app).get("/freshrss/unread", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid or missing API token"}
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_unread_accepts_valid_credentials(monkeypatch):
+    main = import_app(monkeypatch)
+    monkeypatch.setattr(main, "get_greader_token", lambda: "fresh-token")
+    monkeypatch.setattr(main.requests, "get", lambda *args, **kwargs: FakeResponse(payload={"items": []}))
+
+    response = TestClient(main.app).get(
+        "/freshrss/unread",
+        headers={"Authorization": "Bearer api-test-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 def test_get_greader_token_logs_in_once_and_caches_token(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,8 +19,9 @@ REQUIRED_ENV = {
     "FRESHRSS_HOST": "https://freshrss.example.test",
     "FRESHRSS_USER": "reader",
     "FRESHRSS_PASS": "secret",
-    "RSS_API_TOKEN": "api-test-token",
 }
+
+AUTH_TOKEN_VALUE = "api-test-token"
 
 
 class FakeResponse:
@@ -114,6 +115,7 @@ def test_health_endpoint_returns_json_over_http(test_client):
 def test_unread_rejects_unauthorized_requests_without_contacting_freshrss(
     test_client, monkeypatch, main_module, headers
 ):
+    main_module.RSS_API_TOKEN = AUTH_TOKEN_VALUE  # enable auth for this test
     monkeypatch.setattr(main_module, "get_greader_token", lambda: "unreachable")
 
     def unexpected_request(*args, **kwargs):
@@ -130,6 +132,7 @@ def test_unread_rejects_unauthorized_requests_without_contacting_freshrss(
 
 
 def test_unread_accepts_valid_credentials(test_client, monkeypatch, main_module):
+    main_module.RSS_API_TOKEN = AUTH_TOKEN_VALUE  # enable auth for this test
     calls = install_freshrss_transport(monkeypatch, main_module)
 
     response = test_client.get(


### PR DESCRIPTION
## Summary

Merges `codex/add-api-authentication-with-tests` with the latest `main` (13 commits ahead) and makes `RSS_API_TOKEN` optional.

When `RSS_API_TOKEN` is **not set**, the API works exactly as before — no authentication required. Set it to a long random secret to require `Authorization: Bearer <token>` on `/freshrss/unread`.

## Changes

- **`RSS_API_TOKEN` is optional** — removed from the required-env startup check
- `require_api_token()` passes through when token is not configured
- Merged all 13 commits from `main` (Pydantic validation, reauth, URL encoding, etc.)
- Resolved merge conflicts in `main.py`, `tests/test_main.py`, `docker-compose.yml`, `README.md`
- `docker-compose.yml` uses `${RSS_API_TOKEN:-}` — safe default to empty
- Tests: 48/48 pass, auth off by default, auth-specific tests enable token at runtime
- Added `test_unread_allows_requests_when_token_not_configured` — proves no-auth mode works

## Docker Image Impact

- **No Dockerfile changes** — image builds identically
- Container starts without `RSS_API_TOKEN` — backward compatible
- If user sets `RSS_API_TOKEN`, auth is enforced; if not, everything works as today

## Test Plan

```bash
uv sync && uv run pytest tests/ -v  # 48 passed
```