### PR TITLE
ci: split test and Docker workflows for independent maintenance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,36 +1,14 @@
-name: Test, Build, and Push Docker image
+name: Build and Push Docker image
 
 on:
-  pull_request:
-  push:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
     branches: [main]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-
-      - name: Install dependencies
-        run: uv sync --frozen
-
-      - name: Run tests
-        run: uv run pytest
-
   build-push:
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rss-api
 
-[![Tests](https://github.com/Skulldorom/rss-api/actions/workflows/docker.yml/badge.svg)](https://github.com/Skulldorom/rss-api/actions/workflows/docker.yml)
+[![Tests](https://github.com/Skulldorom/rss-api/actions/workflows/test.yml/badge.svg)](https://github.com/Skulldorom/rss-api/actions/workflows/test.yml)
+[![Docker](https://github.com/Skulldorom/rss-api/actions/workflows/docker.yml/badge.svg)](https://github.com/Skulldorom/rss-api/actions/workflows/docker.yml)
 
 Simple API to fetch rss feeds for github releases using fresh rss (powered by FastAPI)
 


### PR DESCRIPTION
## Summary

Splits the monolithic CI workflow into two independent files:

**`.github/workflows/test.yml`** — runs on every PR and push to `main`. Tests only, no Docker.
**`.github/workflows/docker.yml`** — triggers via `workflow_run` only when tests pass on `main`. Builds and publishes the Docker image.

## Design

| Trigger | What runs |
|---|---|
| PR opened/updated | Tests only (fast feedback, no image build) |
| Push to main | Tests → if pass → Docker build+push |
| Push to other branches | Nothing (no wasted CI) |

The Docker workflow uses `workflow_run` with `conclusion == 'success'` gating so the image is only published after verified tests on `main`.

## Why

- Tests and Docker are now independently maintainable — no more editing the same file for both concerns
- Running tests on PR doesn't need to know about Docker infrastructure
- The two badge approach (test + Docker) gives visibility into both pipelines

## README badges

```markdown
[![Tests](.../test.yml/badge.svg)](...)
[![Docker](.../docker.yml/badge.svg)](...)
```

Note: the Docker badge will show "no status" until this PR is merged and the `workflow_run` triggers for the first time on `main`.